### PR TITLE
fix: improve average yearly rent naming

### DIFF
--- a/src/components/cards/main/PropertiesCard.tsx
+++ b/src/components/cards/main/PropertiesCard.tsx
@@ -65,7 +65,7 @@ export const PropertiesCard: FC = () => {
         <DecimalField label={t('tokens')} value={sumRealtokens} />
         <IntegerField label={t('properties')} value={sumProperties} />
         <CurrencyField label={t('averageValue')} value={meanValue} />
-        <CurrencyField label={t('averageRent')} value={meanRents} />
+        <CurrencyField label={t('averageYearlyRent')} value={meanRents} />
         <RentedUnitsField label={t('rentedUnits')} realtokens={realtokens} />
       </Box>
     </Card>

--- a/src/i18next/locales/en/common.json
+++ b/src/i18next/locales/en/common.json
@@ -17,8 +17,8 @@
     "light": "Light",
     "dark": "Dark",
     "refreshDataButton": "Refresh data",
-    "realtime":"Realtime",
-    "global":"Global"
+    "realtime": "Realtime",
+    "global": "Global"
   },
   "walletButton": {
     "connectWallet": "Connect wallet",
@@ -82,7 +82,7 @@
     "tokens": "Tokens",
     "properties": "Properties",
     "averageValue": "Average value",
-    "averageRent": "Average rent",
+    "averageYearlyRent": "Average yearly rent",
     "rentedUnits": "Rented units"
   },
   "assetView": {
@@ -175,7 +175,7 @@
     "rentedUnits": "Rented units",
     "propertyValue": "Property value",
     "rentStartDate": "Rent Start",
-    "rentNotStarted":"Rent not started yet",
+    "rentNotStarted": "Rent not started yet",
     "isRmmAvailable": "RMM",
     "rentStatus": {
       "full": "Rented",
@@ -219,7 +219,7 @@
       "rentWeek": "Weekly rent",
       "rentMonth": "Monthly rent",
       "rentYear": "Yearly rent",
-      "rentedUnits":"Rented units"
+      "rentedUnits": "Rented units"
     },
     "property": {
       "initialLaunchDate": "Launch date",

--- a/src/i18next/locales/fr/common.json
+++ b/src/i18next/locales/fr/common.json
@@ -17,8 +17,8 @@
     "light": "Clair",
     "dark": "Sombre",
     "refreshDataButton": "Actualiser les données",
-    "realtime":"Temps réel",
-    "global":"Global"
+    "realtime": "Temps réel",
+    "global": "Global"
   },
   "walletButton": {
     "connectWallet": "Connecter mon portefeuille",
@@ -82,7 +82,7 @@
     "tokens": "Tokens",
     "properties": "Propriétés",
     "averageValue": "Valeur moyenne",
-    "averageRent": "Loyer moyen",
+    "averageYearlyRent": "Loyer annuel moyen",
     "rentedUnits": "Logements loués"
   },
   "assetView": {
@@ -175,7 +175,7 @@
     "rentedUnits": "Logements loués",
     "propertyValue": "Valeur de la propriété",
     "rentStartDate": "Date du premier loyer",
-    "rentNotStarted":"Le loyer n'a pas débuté",
+    "rentNotStarted": "Le loyer n'a pas débuté",
     "isRmmAvailable": "RMM",
     "rentStatus": {
       "full": "Louée",
@@ -219,7 +219,7 @@
       "rentWeek": "Loyer hebdomadaire",
       "rentMonth": "Loyer mensuel",
       "rentYear": "Loyer annuel",
-      "rentedUnits":"Logements loués"
+      "rentedUnits": "Logements loués"
     },
     "property": {
       "initialLaunchDate": "Mise en vente",


### PR DESCRIPTION
I notice that **average yearly rent** was label as **average rent** witch can be miss understand as **monthly rent**. So I fixed the miss understand
Same for french translation