### PR TITLE
✨feat: add selector for the amount of thumbnails per page

### DIFF
--- a/src/components/assetsView/views/AssetGrid.tsx
+++ b/src/components/assetsView/views/AssetGrid.tsx
@@ -18,7 +18,7 @@ import { AssetCard } from '../../cards'
 export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
   const router = useRouter()
   const [page, setPage] = useState<number>(1)
-  const pageSize = 24
+  const [pageSize, setPageSize] = useState<number>(20)
 
   function onPageChange(page: number) {
     setPage(page)
@@ -39,25 +39,18 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
     onDropdownClose: () => combobox.resetSelectedOption(),
   })
 
-  const values = [24, 48, 96, 192, 384, 768, 1536]
+  const values = [20, 40, 100, 200]
 
-  const [search, setSearch] = useState('')
-  const [value, setValue] = useState<string | null>('24')
-  const [data, setData] = useState<string[]>(
-    values.map((item) => item.toString()),
-  )
-
-  const exactOptionMatch = data.some((item) => item === search)
-  const filteredOptions = exactOptionMatch
-    ? data
-    : data.filter((item) =>
-        item.toLowerCase().includes(search.toLowerCase().trim()),
-      )
-  const options = filteredOptions.map((item) => (
-    <Combobox.Option value={item} key={item}>
-      {item}
-    </Combobox.Option>
-  ))
+  const options = [
+    <Combobox.Option value={'All'} key={'All'}>
+      {'All'}
+    </Combobox.Option>,
+    ...values.map((item) => (
+      <Combobox.Option value={item.toString()} key={item}>
+        {item}
+      </Combobox.Option>
+    )),
+  ]
 
   return (
     <>
@@ -90,13 +83,8 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
           store={combobox}
           withinPortal={false}
           onOptionSubmit={(val) => {
-            if (val === '$create') {
-              setData((current) => [...current, search])
-              setValue(search)
-            } else {
-              setValue(val)
-              setSearch(val)
-            }
+            if (val === 'All') return setPageSize(props.realtokens.length)
+            setPageSize(Number(val))
 
             combobox.closeDropdown()
           }}
@@ -104,17 +92,16 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
           <Combobox.Target>
             <InputBase
               rightSection={<Combobox.Chevron />}
-              value={search}
-              onChange={(event) => {
+              value={pageSize == props.realtokens.length ? 'All' : pageSize}
+              type={'button'}
+              onChange={() => {
                 combobox.openDropdown()
                 combobox.updateSelectedOptionIndex()
-                setSearch(event.currentTarget.value)
               }}
               onClick={() => combobox.openDropdown()}
               onFocus={() => combobox.openDropdown()}
               onBlur={() => {
                 combobox.closeDropdown()
-                setSearch(value || '')
               }}
               placeholder={'Search value'}
               rightSectionPointerEvents={'none'}

--- a/src/components/assetsView/views/AssetGrid.tsx
+++ b/src/components/assetsView/views/AssetGrid.tsx
@@ -2,7 +2,14 @@ import { FC, useEffect, useMemo, useState } from 'react'
 
 import { useRouter } from 'next/router'
 
-import { Grid, Group, Pagination } from '@mantine/core'
+import {
+  Combobox,
+  Grid,
+  Group,
+  InputBase,
+  Pagination,
+  useCombobox,
+} from '@mantine/core'
 
 import { UserRealtoken } from 'src/store/features/wallets/walletsSelector'
 
@@ -27,6 +34,30 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
 
   // Go to first page when data changes (e.g. search, filter, order, ...)
   useEffect(() => setPage(1), [props.realtokens])
+
+  const combobox = useCombobox({
+    onDropdownClose: () => combobox.resetSelectedOption(),
+  })
+
+  const values = [24, 48, 96, 192, 384, 768, 1536]
+
+  const [search, setSearch] = useState('')
+  const [value, setValue] = useState<string | null>('24')
+  const [data, setData] = useState<string[]>(
+    values.map((item) => item.toString()),
+  )
+
+  const exactOptionMatch = data.some((item) => item === search)
+  const filteredOptions = exactOptionMatch
+    ? data
+    : data.filter((item) =>
+        item.toLowerCase().includes(search.toLowerCase().trim()),
+      )
+  const options = filteredOptions.map((item) => (
+    <Combobox.Option value={item} key={item}>
+      {item}
+    </Combobox.Option>
+  ))
 
   return (
     <>
@@ -55,6 +86,45 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
           size={'sm'}
           onChange={onPageChange}
         />
+        <Combobox
+          store={combobox}
+          withinPortal={false}
+          onOptionSubmit={(val) => {
+            if (val === '$create') {
+              setData((current) => [...current, search])
+              setValue(search)
+            } else {
+              setValue(val)
+              setSearch(val)
+            }
+
+            combobox.closeDropdown()
+          }}
+        >
+          <Combobox.Target>
+            <InputBase
+              rightSection={<Combobox.Chevron />}
+              value={search}
+              onChange={(event) => {
+                combobox.openDropdown()
+                combobox.updateSelectedOptionIndex()
+                setSearch(event.currentTarget.value)
+              }}
+              onClick={() => combobox.openDropdown()}
+              onFocus={() => combobox.openDropdown()}
+              onBlur={() => {
+                combobox.closeDropdown()
+                setSearch(value || '')
+              }}
+              placeholder={'Search value'}
+              rightSectionPointerEvents={'none'}
+            />
+          </Combobox.Target>
+
+          <Combobox.Dropdown>
+            <Combobox.Options>{options}</Combobox.Options>
+          </Combobox.Dropdown>
+        </Combobox>
       </Group>
     </>
   )

--- a/src/components/assetsView/views/AssetGrid.tsx
+++ b/src/components/assetsView/views/AssetGrid.tsx
@@ -27,13 +27,16 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
   }
 
   const paginationOffers: UserRealtoken[] = useMemo(() => {
+    console.log({ realtokens: props.realtokens })
+    if (pageSize === Infinity) return props.realtokens
+
     const start = (page - 1) * pageSize
     const end = start + pageSize
     return props.realtokens.slice(start, end)
   }, [props.realtokens, page, pageSize])
 
   // Go to first page when data changes (e.g. search, filter, order, ...)
-  useEffect(() => setPage(1), [props.realtokens])
+  // useEffect(() => setPage(1), [props.realtokens])
 
   const combobox = useCombobox({
     onDropdownClose: () => combobox.resetSelectedOption(),
@@ -73,7 +76,11 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
       >
         <Pagination
           value={page}
-          total={Math.ceil(props.realtokens.length / pageSize)}
+          total={
+            pageSize === Infinity
+              ? 0
+              : Math.ceil(props.realtokens.length / pageSize)
+          }
           boundaries={1}
           siblings={1}
           size={'sm'}
@@ -83,7 +90,7 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
           store={combobox}
           withinPortal={false}
           onOptionSubmit={(val) => {
-            if (val === 'All') return setPageSize(props.realtokens.length)
+            if (val === 'All') return setPageSize(Infinity)
             setPageSize(Number(val))
 
             combobox.closeDropdown()
@@ -92,7 +99,7 @@ export const AssetGrid: FC<{ realtokens: UserRealtoken[] }> = (props) => {
           <Combobox.Target>
             <InputBase
               rightSection={<Combobox.Chevron />}
-              value={pageSize == props.realtokens.length ? 'All' : pageSize}
+              value={pageSize == Infinity ? 'All' : pageSize}
               type={'button'}
               onChange={() => {
                 combobox.openDropdown()


### PR DESCRIPTION
This PR introduces a feature requested by @jojodunet that allows users to choose the number of thumbnails displayed per page in the grid view. This enhancement is accessible at the end of the page and offers multiple choice options to suit different user preferences. Additionally, there is an option to display all thumbnails on a single page.