### PR TITLE
feat: add bridge link on header

### DIFF
--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -113,6 +113,13 @@ export const Header: FC = () => {
           label={t('YAM')}
           leftSection={<IconExternalLink size={'1rem'} stroke={1.5} />}
         />
+        <NavLink
+          component={'a'}
+          href={'https://bridge.realtoken.network/'}
+          target={'_blank'}
+          label={t('Bridge')}
+          leftSection={<IconExternalLink size={'1rem'} stroke={1.5} />}
+        />
       </Drawer>
       <div>
         <Box className={styles.container}>

--- a/src/i18next/locales/en/common.json
+++ b/src/i18next/locales/en/common.json
@@ -8,7 +8,8 @@
     "home": "Home",
     "realt": "RealT",
     "RMM": "RMM",
-    "YAM": "YAM"
+    "YAM": "YAM",
+    "Bridge": "Bridge"
   },
   "settings": {
     "title": "Language",

--- a/src/i18next/locales/fr/common.json
+++ b/src/i18next/locales/fr/common.json
@@ -8,7 +8,8 @@
     "home": "Accueil",
     "realt": "RealT",
     "RMM": "RMM",
-    "YAM": "YAM"
+    "YAM": "YAM",
+    "Bridge": "Bridge"
   },
   "settings": {
     "title": "Langue",


### PR DESCRIPTION
Simple addition of a link that redirects to the bridge

We can see the result in the image below

I think it's a good idea to centralize the elements to make them more easily accessible

![image](https://github.com/user-attachments/assets/3ec6de9c-24d7-40b1-90a2-4ce0f3df8ecb)
