### PR TITLE
fix: unchecked asset filters

### DIFF
--- a/src/components/assetsView/filters/AssetsViewRentStatusFilter.tsx
+++ b/src/components/assetsView/filters/AssetsViewRentStatusFilter.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Select } from '@mantine/core'
 
+import { assetsViewDefaultFilter } from 'src/states'
 import {
   OtherRealtoken,
   UserRealtoken,
@@ -50,7 +51,11 @@ export const AssetsViewRentStatusFilter: FC<
       data={viewOptions}
       value={filter.rentStatus}
       onChange={(value) =>
-        onChange({ rentStatus: value as AssetRentStatusType })
+        onChange({
+          rentStatus:
+            (value as AssetRentStatusType) ??
+            assetsViewDefaultFilter.rentStatus,
+        })
       }
       classNames={inputClasses}
     />

--- a/src/components/assetsView/filters/AssetsViewRmmStatusFilter.tsx
+++ b/src/components/assetsView/filters/AssetsViewRmmStatusFilter.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Select } from '@mantine/core'
 
+import { assetsViewDefaultFilter } from 'src/states'
 import {
   OtherRealtoken,
   UserRealtoken,
@@ -46,7 +47,12 @@ export const AssetsViewRmmStatusFilter: FC<AssetsViewRmmStatusFilterProps> = ({
       label={t('label')}
       data={viewOptions}
       value={filter.rmmStatus}
-      onChange={(value) => onChange({ rmmStatus: value as AssetRmmStatusType })}
+      onChange={(value) =>
+        onChange({
+          rmmStatus:
+            (value as AssetRmmStatusType) ?? assetsViewDefaultFilter.rmmStatus,
+        })
+      }
       classNames={inputClasses}
     />
   )

--- a/src/components/assetsView/filters/AssetsViewSort.tsx
+++ b/src/components/assetsView/filters/AssetsViewSort.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 
 import { Grid, Select, Switch } from '@mantine/core'
 
+import { assetsViewDefaultFilter } from 'src/states'
 import { selectTransfersIsLoaded } from 'src/store/features/transfers/transfersSelector'
 import {
   OtherRealtoken,
@@ -73,7 +74,11 @@ export const AssetsViewSort: FC<AssetsViewSortProps> = ({
           data={sortOptions}
           value={filter.sortBy}
           onChange={(value) =>
-            onChange({ ...filter, sortBy: value as AssetSortType })
+            onChange({
+              ...filter,
+              sortBy:
+                (value as AssetSortType) ?? assetsViewDefaultFilter.sortBy,
+            })
           }
           classNames={inputClasses}
         />

--- a/src/components/assetsView/filters/AssetsViewSubsidyFilter.tsx
+++ b/src/components/assetsView/filters/AssetsViewSubsidyFilter.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Select } from '@mantine/core'
 
+import { assetsViewDefaultFilter } from 'src/states'
 import {
   OtherRealtoken,
   UserRealtoken,
@@ -66,7 +67,12 @@ export const AssetsViewSubsidyFilter: FC<AssetsViewSubsidyFilterProps> = ({
       label={t('label')}
       data={viewOptions}
       value={filter.subsidy}
-      onChange={(value) => onChange({ subsidy: value as AssetSubsidyType })}
+      onChange={(value) =>
+        onChange({
+          subsidy:
+            (value as AssetSubsidyType) ?? assetsViewDefaultFilter.subsidy,
+        })
+      }
       classNames={inputClasses}
     />
   )

--- a/src/components/assetsView/filters/AssetsViewUserProtocolFilter.tsx
+++ b/src/components/assetsView/filters/AssetsViewUserProtocolFilter.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Select } from '@mantine/core'
 
+import { assetsViewDefaultFilter } from 'src/states'
 import {
   OtherRealtoken,
   UserRealtoken,
@@ -54,7 +55,11 @@ export const AssetsViewUserProtocolFilter: FC<
       data={viewOptions}
       value={filter.userProtocol}
       onChange={(value) =>
-        onChange({ userProtocol: value as AssetUserProtocolType })
+        onChange({
+          userProtocol:
+            (value as AssetUserProtocolType) ??
+            assetsViewDefaultFilter.userProtocol,
+        })
       }
       classNames={inputClasses}
     />

--- a/src/components/assetsView/filters/AssetsViewUserStatusFilter.tsx
+++ b/src/components/assetsView/filters/AssetsViewUserStatusFilter.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Select } from '@mantine/core'
 
+import { assetsViewDefaultFilter } from 'src/states'
 import {
   OtherRealtoken,
   UserRealtoken,
@@ -58,7 +59,11 @@ export const AssetsViewUserStatusFilter: FC<
       data={viewOptions}
       value={filter.userStatus}
       onChange={(value) =>
-        onChange({ userStatus: value as AssetUserStatusType })
+        onChange({
+          userStatus:
+            (value as AssetUserStatusType) ??
+            assetsViewDefaultFilter.userStatus,
+        })
       }
       classNames={inputClasses}
     />


### PR DESCRIPTION
#### Summary:
This PR fixes a bug in the Asset Filter Modal where the selected filter value becomes `undefined`, leading to unexpected behavior.

#### Steps to Reproduce:
1. Open the **Asset Filter Modal** and select a filter.
2. Submit the filter (by clicking the **Submit** button).
3. Return to the **Asset Filter Modal**, reselect the same filter, and click **Back**.
4. The filter value is set to `undefined`.
5. When you resubmit, all previously shown assets disappear.

#### Fix:
- Ensure the filter value is set to default value if current value is unchecked

#### Bug illustration
<img width="200" alt="Capture d’écran 2024-12-17 à 21 14 48" src="https://github.com/user-attachments/assets/4e5c584b-db3c-4878-9c86-baf7a9e1631a" /> -> <img width="200" alt="Capture d’écran 2024-12-17 à 21 20 52" src="https://github.com/user-attachments/assets/8096aa8a-6636-4678-bad8-e1933d2166de" />
<img width="1153" alt="Capture d’écran 2024-12-17 à 21 21 24" src="https://github.com/user-attachments/assets/ba3251b5-53fc-4956-b4a3-070913e61636" />
