### PR TITLE
feat: add workflow to restrict merges to master

### DIFF
--- a/.github/workflows/branch-check-master.yml
+++ b/.github/workflows/branch-check-master.yml
@@ -1,0 +1,17 @@
+name: Restrict merges to master
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-branch-master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the source branch is preprod
+        run: |
+          if [ "${{ github.event.pull_request.head.ref }}" != "preprod" ]; then
+            echo "Pull requests to master must come from preprod branch."
+            exit 1
+          fi


### PR DESCRIPTION
This new workflow, combined with the main branch protection rules, ensures that only pre-production (preprod) pull requests can be merged into the main branch. Any PRs created from other branches will fail this test, and the branch protection rules will prevent them from being merged.

Preview of a PRs that don't follow the rules (this PR and #104 ):
<img width="912" alt="Capture d’écran 2024-12-19 à 02 25 09" src="https://github.com/user-attachments/assets/ea2daedc-c430-4d69-8468-a7313d788374" />
<img width="912" alt="Capture d’écran 2024-12-19 à 02 26 33" src="https://github.com/user-attachments/assets/5dc128b9-65e8-41c3-ac47-849254df833b" />

